### PR TITLE
Fix Armadillo API error logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1899,6 +1899,16 @@
         "vary": "~1.1.2"
       }
     },
+    "express-promise-router": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/express-promise-router/-/express-promise-router-3.0.3.tgz",
+      "integrity": "sha1-Xm0ipaPwE9cYMxcv6NereAw/a3A=",
+      "requires": {
+        "is-promise": "^2.1.0",
+        "lodash.flattendeep": "^4.0.0",
+        "methods": "^1.0.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3327,6 +3337,11 @@
         "isobject": "^3.0.1"
       }
     },
+    "is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -3699,8 +3714,7 @@
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "bitcoinjs-lib": "^3.2.0",
     "deep-diff": "^1.0.2",
     "express": "^4.17.1",
+    "express-promise-router": "^3.0.3",
     "log4js": "^3.0.6",
     "mongodb": "^3.1.13",
     "node-fetch": "^2.6.0",

--- a/src/api-runner.ts
+++ b/src/api-runner.ts
@@ -23,7 +23,7 @@ function logErrors(err, req, res, next) {
 }
 
 function errorHandler(err, req, res, next) {
-    res.status(500).send(new MessageResponse("Something was wrong", false));
+    res.status(500).send(new MessageResponse("Something went wrong", false));
 }
 
 function starBtcApi(){
@@ -40,12 +40,11 @@ function starBtcApi(){
     app.use(errorHandler);
 
     var apiServer = app.listen(apiConfig.forkApi.PORT, () => {
-        apiConfig.logger.log.debug(`API server running on port ${apiConfig.forkApi.PORT}`);
+        apiConfig.logger.log.info(`API server running on port ${apiConfig.forkApi.PORT}`);
     });
   
     process.on('SIGINT', async () => {
-        
-        apiConfig.logger.log.debug(`Caught interrupt signal - closing API server running on port ${apiConfig.forkApi.PORT}`);
+        apiConfig.logger.log.info(`Caught interrupt signal - closing API server running on port ${apiConfig.forkApi.PORT}`);
         apiServer.close();
         process.exit();
     });

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,4 +1,5 @@
-import * as express from "express"
+import PromiseRouter from "express-promise-router"
+import express from "express"
 import { MainchainService } from "../services/mainchain-service";
 import ForkController from "./controllers/fork-controller";
 import { MongoStore } from "../storage/mongo-store";
@@ -7,7 +8,7 @@ import { MainchainController } from "./controllers/mainchain-controller";
 import { ForkService } from "../services/fork-service";
 
 export function routersConfig(forkStore: MongoStore, mainchainStore: MongoStore, config: any): express.Router {
-        const router: express.Router = express.Router();
+        const router: express.Router = PromiseRouter();
         const mainchainService: MainchainService = new MainchainService(mainchainStore);
         const forkService: ForkService = new ForkService(forkStore);
         const forkController: ForkController = new ForkController(forkService);


### PR DESCRIPTION
Express v4.X.X doesn't handle promises really well, causing errors from rejected promises (that is, any controller's method) not being logged by the custom logger middleware which uses log4js.

Use PromiseRouter from [express-promise-router](https://github.com/express-promise-router/express-promise-router) library to correctly handle async controller methods.